### PR TITLE
SRGMediaPlayerPreviousPlaybackStateKey is always identical to SRGMediaPlayerPlaybackStateKey

### DIFF
--- a/Framework/Sources/Controller/SRGLetterboxController.m
+++ b/Framework/Sources/Controller/SRGLetterboxController.m
@@ -184,8 +184,6 @@ static NSString *SRGDataProviderBusinessUnitIdentifierForVendor(SRGVendor vendor
     NSDictionary *userInfo = @{ SRGMediaPlayerPlaybackStateKey : @(playbackState),
                                 SRGMediaPlayerPreviousPlaybackStateKey: @(_playbackState) };
     
-
-    
     [self willChangeValueForKey:@keypath(self.playbackState)];
     _playbackState = playbackState;
     [self didChangeValueForKey:@keypath(self.playbackState)];

--- a/Tests/Sources/LetterboxControllerTestCase.m
+++ b/Tests/Sources/LetterboxControllerTestCase.m
@@ -437,7 +437,6 @@
     [self waitForExpectationsWithTimeout:5. handler:nil];
 }
 
-
 - (void)testPlaybackStateKeyValueObserving
 {
     [self keyValueObservingExpectationForObject:self.controller keyPath:@"playbackState" expectedValue:@(SRGMediaPlayerPlaybackStatePreparing)];


### PR DESCRIPTION
SRGLetterboxControllerPlaybackStateDidChangeNotification userinfo was set with the same value for both  `SRGMediaPlayerPreviousPlaybackStateKey` and `SRGMediaPlayerPlaybackStateKey`

The `SRGMediaPlayerPreviousPlaybackStateKey` was using `_playbackState` which was already replaced with the new `playbackState` value