### PR TITLE
Feature/274 ios timeline view not interactive in some cases

### DIFF
--- a/Sources/SRGLetterbox/SRGControlsView~ios.m
+++ b/Sources/SRGLetterbox/SRGControlsView~ios.m
@@ -50,8 +50,6 @@ static NSDateComponentsFormatter *SRGControlsViewSkipIntervalAccessibilityFormat
 
 @interface SRGControlsView ()
 
-@property (nonatomic, weak) UIView *userInterfaceToggleActiveView;
-
 @property (nonatomic, weak) SRGLetterboxPlaybackButton *playbackButton;
 @property (nonatomic, weak) SRGLabeledControlButton *backwardSkipButton;
 @property (nonatomic, weak) SRGLabeledControlButton *forwardSkipButton;
@@ -92,7 +90,6 @@ static NSDateComponentsFormatter *SRGControlsViewSkipIntervalAccessibilityFormat
 {
     [super layoutContentView];
     
-    [self layoutUserInterfaceToggleActiveViewInView:self.contentView];
     [self layoutBottomControlsInView:self.contentView];
     [self layoutCenterControlsInView:self.contentView];
     
@@ -104,20 +101,6 @@ static NSDateComponentsFormatter *SRGControlsViewSkipIntervalAccessibilityFormat
     }];
 }
 
-- (void)layoutUserInterfaceToggleActiveViewInView:(UIView *)view
-{
-    UIView *userInterfaceToggleActiveView = [[UIView alloc] init];
-    [view addSubview:userInterfaceToggleActiveView];
-    self.userInterfaceToggleActiveView = userInterfaceToggleActiveView;
-    
-    userInterfaceToggleActiveView.translatesAutoresizingMaskIntoConstraints = NO;
-    [NSLayoutConstraint activateConstraints:@[
-        [userInterfaceToggleActiveView.topAnchor constraintEqualToAnchor:view.topAnchor],
-        [userInterfaceToggleActiveView.leadingAnchor constraintEqualToAnchor:view.leadingAnchor],
-        [userInterfaceToggleActiveView.trailingAnchor constraintEqualToAnchor:view.trailingAnchor],
-    ]];
-}
-
 - (void)layoutBottomControlsInView:(UIView *)view
 {
     UIStackView *bottomStackView = [[UIStackView alloc] init];
@@ -126,7 +109,6 @@ static NSDateComponentsFormatter *SRGControlsViewSkipIntervalAccessibilityFormat
     
     bottomStackView.translatesAutoresizingMaskIntoConstraints = NO;
     [NSLayoutConstraint activateConstraints:@[
-        [bottomStackView.topAnchor constraintEqualToAnchor:self.userInterfaceToggleActiveView.bottomAnchor],
         [[bottomStackView.bottomAnchor constraintEqualToAnchor:view.bottomAnchor] srgletterbox_withPriority:750],
         [bottomStackView.bottomAnchor constraintLessThanOrEqualToAnchor:view.safeAreaLayoutGuide.bottomAnchor],
         [bottomStackView.leadingAnchor constraintEqualToAnchor:view.safeAreaLayoutGuide.leadingAnchor],

--- a/Sources/SRGLetterbox/SRGLetterboxView~ios.m
+++ b/Sources/SRGLetterbox/SRGLetterboxView~ios.m
@@ -171,18 +171,18 @@ static const CGFloat kBottomConstraintLesserPriority = 850.f;
     
     UITapGestureRecognizer *singleTapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleSingleTap:)];
     singleTapGestureRecognizer.delegate = self;
-    [self addGestureRecognizer:singleTapGestureRecognizer];
+    [playbackView addGestureRecognizer:singleTapGestureRecognizer];
     self.singleTapGestureRecognizer = singleTapGestureRecognizer;
     
     SRGTapGestureRecognizer *doubleTapGestureRecognizer = [[SRGTapGestureRecognizer alloc] initWithTarget:self action:@selector(handleSkip:)];
     doubleTapGestureRecognizer.numberOfTapsRequired = 2;
     doubleTapGestureRecognizer.delaysTouchesEnded = NO;
     doubleTapGestureRecognizer.tapDelay = 0.25;
-    [self addGestureRecognizer:doubleTapGestureRecognizer];
+    [playbackView addGestureRecognizer:doubleTapGestureRecognizer];
     self.doubleTapGestureRecognizer = doubleTapGestureRecognizer;
     
     UIPinchGestureRecognizer *videoGravityChangePinchGestureRecognizer = [[UIPinchGestureRecognizer alloc] initWithTarget:self action:@selector(handleVideoGravityPinch:)];
-    [self addGestureRecognizer:videoGravityChangePinchGestureRecognizer];
+    [playbackView addGestureRecognizer:videoGravityChangePinchGestureRecognizer];
 }
 
 - (void)layoutControlsViewInView:(UIView *)view

--- a/Sources/SRGLetterbox/SRGLetterboxView~ios.m
+++ b/Sources/SRGLetterbox/SRGLetterboxView~ios.m
@@ -119,7 +119,7 @@ static const CGFloat kBottomConstraintLesserPriority = 850.f;
     
     [self layoutTimelineViewInView:self.contentView];
     [self layoutPlayerViewInView:self.contentView];
-    [self layoutControlsViewInView:self.contentView];
+    [self layoutControlsViewInView:self.playbackView];
     [self layoutNotificationViewInView:self.contentView];
     [self layoutAvailabilityViewInView:self.contentView];
     [self layoutContinuousPlaybackViewInView:self.contentView];
@@ -402,7 +402,7 @@ static const CGFloat kBottomConstraintLesserPriority = 850.f;
     
     UIView *mediaPlayerView = controller.mediaPlayerController.view;
     if (mediaPlayerView) {
-        [self.playbackView addSubview:mediaPlayerView];
+        [self.playbackView insertSubview:mediaPlayerView atIndex:0];
         
         // Force autolayout to ensure the layout is immediately correct
         mediaPlayerView.translatesAutoresizingMaskIntoConstraints = NO;


### PR DESCRIPTION
### Motivation and Context

When the player is in an `idle` or `eof` state, Letterbox view displays the timeline view for content with segments or related chapters.
The timeline can scroll horizontally, but the tap on a timeline cell does not select its.

With the build for Mac (Designed for iPad – for Mac Apple Silicon), in any player state, the timeline can scroll horizontally, but the tap on a timeline cell does not select its.

### Description

See #274.

- Move back gestures to the `playbackView` and don't cover the timeline view frame.
- Move controls views to the `playbackView` subviews so that all gestures are supported, as before.
- remove unused view in `SRGControlsView`. 

### Checklist

- [x] The branch has been rebased onto the `develop` branch.
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.
