### PR TITLE
Fastlane builds ignore bitcode

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -23,7 +23,7 @@ platform :ios do
       end
     end
 
-    ensure_git_status_clean unless lane.to_s.downcase.include? 'dsym'
+    ensure_git_status_clean
 
     xcversion(version: '~> 14')
   end
@@ -91,21 +91,9 @@ platform :ios do
     testflight_nightlies(platform: 'tvOS')
   end
 
-  desc 'Send latest tvOS nightly dSYMs to App Center. Optional \'build_number\', \'version\' or \'min_version\' parameters.'
-  lane :tvOSnightlyDSYMs do |options|
-    appcenter_appname = ENV['LETTERBOX_DEMO_TVOS_NIGHTLY_APPCENTER_APPNAME']
-    update_dsyms('tvOS', appcenter_appname, options)
-  end
-
   desc 'Build a new iOS nightly demo on AppStore Connect and wait build processing.'
   lane :iOSnightly do
     testflight_nightlies(platform: 'iOS')
-  end
-
-  desc 'Send latest iOS nightly dSYMs to App Center. Optional \'build_number\', \'version\' or \'min_version\' parameters.'
-  lane :iOSnightlyDSYMs do |options|
-    appcenter_appname = ENV['LETTERBOX_DEMO_IOS_NIGHTLY_APPCENTER_APPNAME']
-    update_dsyms('iOS', appcenter_appname, options)
   end
 
   # Demo
@@ -141,21 +129,9 @@ platform :ios do
     testflight_demo(platform: 'tvOS')
   end
 
-  desc 'Send latest tvOS demo dSYMs to App Center. Optional \'build_number\', \'version\' or \'min_version\' parameters.'
-  lane :tvOSdemoDSYMs do |options|
-    appcenter_appname = ENV['LETTERBOX_DEMO_TVOS_RELEASE_APPCENTER_APPNAME']
-    update_dsyms('tvOS', appcenter_appname, options)
-  end
-
   desc 'Build a new iOS demo on AppStore Connect and wait build processing. You are responsible to tag the library and bump the version (and the build number) after.'
   lane :iOSdemo do
     testflight_demo(platform: 'iOS')
-  end
-
-  desc 'Send latest iOS demo dSYMs to App Center. Optional \'build_number\', \'version\' or \'min_version\' parameters.'
-  lane :iOSdemoDSYMs do |options|
-    appcenter_appname = ENV['LETTERBOX_DEMO_IOS_RELEASE_APPCENTER_APPNAME']
-    update_dsyms('iOS', appcenter_appname, options)
   end
 
   # Private lanes
@@ -184,19 +160,18 @@ platform :ios do
 
     pilot_fast_upload(platform)
 
-    clean_build_artifacts
-
     UI.message "SRGLetterbox-demo (Nightly #{build_number}) uploaded. ✅"
+
+    appcenter_appname = appcenter_testflight_nightly_name(platform)
+    upload_appcenter_dsyms(appcenter_appname)
+
+    UI.message "SRGLetterbox-demo (Nightly #{build_number}) dSYM file OK. ✅"
+
+    clean_build_artifacts
 
     pilot_distribute(platform, build_number, nightly_changelog(platform, service))
 
     UI.message "SRGLetterbox-demo (Nightly #{build_number}) distributed. ✅"
-
-    appcenter_appname = appcenter_testflight_nightly_name(platform)
-    dsyms_options = { build_number: build_number }
-    update_dsyms(platform, appcenter_appname, dsyms_options)
-
-    UI.message "SRGLetterbox-demo (Nightly #{build_number}) dSYM file OK. ✅"
 
     save_last_nightlies_success_git_commit_hash(platform, service)
   end
@@ -232,8 +207,7 @@ platform :ios do
     UI.message "SRGLetterbox-demo (Release #{build_number}) distributed. ✅"
 
     appcenter_appname = appcenter_testflight_demo_name(platform)
-    dsyms_options = { build_number: build_number }
-    update_dsyms(platform, appcenter_appname, dsyms_options)
+    upload_appcenter_dsyms(appcenter_appname)
 
     UI.message "SRGLetterbox-demo (Release #{build_number}) dSYM file OK. ✅"
 
@@ -536,43 +510,14 @@ def srg_pilot_distribute(platform, build_number, changelog)
   xcversion(version: '~> 13')
 end
 
-# Update dSYMs from AppStore Connect to App Center.
-def update_dsyms(platform, appcenter_appname, options)
-  platform ||= 'iOS'
-
-  output_directory = "fastlane/export/#{lane_context[SharedValues::LANE_NAME]}"
-  Dir.chdir('..') { FileUtils.mkdir_p(output_directory) }
-
-  download_appstore_dsyms(platform, options, output_directory)
-  upload_appcenter_dsyms(appcenter_appname)
-
-  lane_context.delete(SharedValues::DSYM_PATHS)
-end
-
-def download_appstore_dsyms(platform, options, output_directory)
-  platform ||= 'iOS'
-  options[:version] ||= 'latest'
-
-  login_with_app_store_connect_api_key
-  download_dsyms(
-    platform: appstore_platform(platform),
-    min_version: options[:build_number] ? nil : options[:min_version],
-    version: options[:min_version] || options[:build_number] ? nil : options[:version],
-    build_number: options[:build_number],
-    output_directory: output_directory,
-    wait_for_dsym_processing: true,
-    wait_timeout: 90
-  )
-end
-
 def upload_appcenter_dsyms(appcenter_appname)
-  lane_context[SharedValues::DSYM_PATHS]&.each do |dsym|
-    appcenter_lane(
-      appname: appcenter_appname,
-      notes: 'DSYMs from AppStore Connect (via fastlane).',
-      upload_dsym: dsym
-    )
-  end
+  dsym = lane_context[SharedValues::DSYM_OUTPUT_PATH]
+  appcenter_lane(
+    appname: appcenter_appname,
+    notes: 'DSYMs from local build (via fastlane).',
+    upload_dsym: dsym
+  )
+  lane_context.delete(SharedValues::DSYM_OUTPUT_PATH)
 end
 
 # Share build number to the continuous integration

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -264,7 +264,7 @@ platform :ios do
       clean: true,
       xcargs: srg_xcargs(options),
       export_method: options[:export_to_appstore] ? 'app-store' : 'enterprise',
-      include_bitcode: options[:export_to_appstore],
+      include_bitcode: false,
       export_team_id: options[:team_id],
       destination: destination,
       derived_data_path: srg_xcodebuild_derived_data_path,
@@ -349,18 +349,18 @@ def update_options_to_appstore(options)
 end
 
 def srg_xcargs(options)
-  export_to_appstore = options[:export_to_appstore] || false
-  xcargs = export_to_appstore ? 'ENABLE_BITCODE=YES' : 'ENABLE_BITCODE=NO'
+  xcargs = 'ENABLE_BITCODE=NO'
   xcargs += " BUNDLE_DISPLAY_NAME_SUFFIX='#{options[:display_name_suffix]}'"
   xcargs += " MARKETING_VERSION='#{options[:version]}'"
   xcargs += " MARKETING_VERSION_SUFFIX='#{options[:version_suffix]}'"
   xcargs += " BUILD_NAME='#{options[:build_name]}'"
   xcargs += " DEVELOPMENT_TEAM='#{options[:team_id]}'"
-  xcargs + srg_xcargs_code_signing(export_to_appstore)
+  xcargs + srg_xcargs_code_signing(options)
 end
 
 # Use cloud signing if available
-def srg_xcargs_code_signing(export_to_appstore)
+def srg_xcargs_code_signing(options)
+  export_to_appstore = options[:export_to_appstore] || false
   asc_api_key = srg_app_store_connect_api_key if export_to_appstore
 
   xcargs = ''

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -39,14 +39,6 @@ Build a new iOS nightly demo on App Center
 
 Build a new tvOS nightly demo on AppStore Connect and wait build processing.
 
-### ios tvOSnightlyDSYMs
-
-```sh
-[bundle exec] fastlane ios tvOSnightlyDSYMs
-```
-
-Send latest tvOS nightly dSYMs to App Center. Optional 'build_number', 'version' or 'min_version' parameters.
-
 ### ios iOSnightly
 
 ```sh
@@ -54,14 +46,6 @@ Send latest tvOS nightly dSYMs to App Center. Optional 'build_number', 'version'
 ```
 
 Build a new iOS nightly demo on AppStore Connect and wait build processing.
-
-### ios iOSnightlyDSYMs
-
-```sh
-[bundle exec] fastlane ios iOSnightlyDSYMs
-```
-
-Send latest iOS nightly dSYMs to App Center. Optional 'build_number', 'version' or 'min_version' parameters.
 
 ### ios demo
 
@@ -79,14 +63,6 @@ Build a new iOS demo on App Center with the current build number. You are respon
 
 Build a new tvOS demo on AppStore Connect and wait build processing. You are responsible to tag the library and bump the version (and the build number) after.
 
-### ios tvOSdemoDSYMs
-
-```sh
-[bundle exec] fastlane ios tvOSdemoDSYMs
-```
-
-Send latest tvOS demo dSYMs to App Center. Optional 'build_number', 'version' or 'min_version' parameters.
-
 ### ios iOSdemo
 
 ```sh
@@ -94,14 +70,6 @@ Send latest tvOS demo dSYMs to App Center. Optional 'build_number', 'version' or
 ```
 
 Build a new iOS demo on AppStore Connect and wait build processing. You are responsible to tag the library and bump the version (and the build number) after.
-
-### ios iOSdemoDSYMs
-
-```sh
-[bundle exec] fastlane ios iOSdemoDSYMs
-```
-
-Send latest iOS demo dSYMs to App Center. Optional 'build_number', 'version' or 'min_version' parameters.
 
 ----
 


### PR DESCRIPTION
### Motivation and Context

Starting with [Xcode 14](https://developer.apple.com/documentation/xcode-release-notes/xcode-14-release-notes), Apple deprecated bitcode.

> Starting with Xcode 14, bitcode is no longer required for watchOS and tvOS applications, and the App Store no longer accepts bitcode submissions from Xcode 14.

- Uploading on AppStoreConnect does not create anymore dSYMs server side.
- The CI waits for dSYMs without any findings and skill after a while.  

### Description

- Remove asynchronous lane to download dSYMs from AppStoreConnect and upload its to AppCenter.
- Upload local dSYMs to AppCenter after the build and build upload to AppStoreConnect.

### Checklist

- [x] The branch has been rebased onto the `develop` branch.
- The code followed the code style:
	-  [x] `swiftlint` has run to ensure the *Swift* code style is valid.
	-  [x] `rubocop -a` has run to ensure the *Ruby* code style is valid.
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.
