### PR TITLE
Replace assertion with simple log

### DIFF
--- a/Sources/SRGLetterbox/UIFont+SRGLetterbox.m
+++ b/Sources/SRGLetterbox/UIFont+SRGLetterbox.m
@@ -13,9 +13,12 @@ __attribute__((constructor)) static void SRGLetterboxFontInit(void)
 {
     dispatch_async(dispatch_get_main_queue(), ^{
         NSURL *fontFileURL = [SWIFTPM_MODULE_BUNDLE URLForResource:@"FontAwesome" withExtension:@"otf"];
-        __unused BOOL success = CTFontManagerRegisterFontsForURL((CFURLRef)fontFileURL, kCTFontManagerScopeProcess, NULL);
-        NSCAssert(success, @"The FontAwesome font could not be registered. Please ensure only SRG Letterbox registers "
-                  "this font (check font declarations in your application Info.plist)");
+        BOOL success = CTFontManagerRegisterFontsForURL((CFURLRef)fontFileURL, kCTFontManagerScopeProcess, NULL);
+        if (! success) {
+            NSLog(@"The FontAwesome font could not be registered. Please ensure only SRG Letterbox registers "
+                  "this font (check font declarations in your application Info.plist). Please ignore this "
+                  "issue in unit tests.");
+        }
     });
 }
 


### PR DESCRIPTION
# Pull request

## Description

This PR avoids crashing unit tests during font registration.

## Changes made

I replaced the assertion with an `NSLog`. Using `NSLog` is in general bad practice but here this is just for warning purposes. Adding a dependency on `SRGLogger` or using `os_log` seemed also a bit too much.