### PR TITLE
Update to Commanders Act version 5

### DIFF
--- a/Demo/Info.plist
+++ b/Demo/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>AVInitialRouteSharingPolicy</key>
+	<string>LongFormVideo</string>
 	<key>AppCenterSecret</key>
 	<string>$(APPCENTER_SECRET)</string>
 	<key>AppCenterURL</key>
@@ -51,8 +53,29 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>The application should not use Bluetooth. Please don’t allow.</string>
+	<key>NSBluetoothPeripheralUsageDescription</key>
+	<string>The application should not use Bluetooth. Please don’t allow.</string>
 	<key>PlayMMFServiceURL</key>
 	<string>$(PLAY_MMF_SERVICE_URL)</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default</string>
+					<key>UISceneDelegateClassName</key>
+					<string>SceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>
@@ -78,26 +101,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>AVInitialRouteSharingPolicy</key>
-	<string>LongFormVideo</string>
 	<key>UIUserInterfaceStyle</key>
 	<string>Automatic</string>
-	<key>UIApplicationSceneManifest</key>
-	<dict>
-		<key>UIApplicationSupportsMultipleScenes</key>
-		<true/>
-		<key>UISceneConfigurations</key>
-		<dict>
-			<key>UIWindowSceneSessionRoleApplication</key>
-			<array>
-				<dict>
-					<key>UISceneConfigurationName</key>
-					<string>Default</string>
-					<key>UISceneDelegateClassName</key>
-					<string>SceneDelegate</string>
-				</dict>
-			</array>
-		</dict>
-	</dict>
 </dict>
 </plist>

--- a/Demo/Info.plist
+++ b/Demo/Info.plist
@@ -53,10 +53,6 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
-	<key>NSBluetoothAlwaysUsageDescription</key>
-	<string>The application should not use Bluetooth. Please don’t allow.</string>
-	<key>NSBluetoothPeripheralUsageDescription</key>
-	<string>The application should not use Bluetooth. Please don’t allow.</string>
 	<key>PlayMMFServiceURL</key>
 	<string>$(PLAY_MMF_SERVICE_URL)</string>
 	<key>UIApplicationSceneManifest</key>

--- a/Demo/SRGLetterbox-demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/SRGLetterbox-demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/CommandersAct/iOSV5.git",
         "state": {
           "branch": null,
-          "revision": "b76b700d92c35f02a3d977e7707ecf4df4732b35",
-          "version": "5.3.2"
+          "revision": "2e56e97db76d55657d0dc7d13e2fcd81ce4eaa6c",
+          "version": "5.3.3"
         }
       },
       {
@@ -87,7 +87,7 @@
         "repositoryURL": "https://github.com/SRGSSR/srganalytics-apple.git",
         "state": {
           "branch": "feature/62-update-to-tag-commander-v5",
-          "revision": "e4b666ff0242b94e8163dcad510a99ede1015be4",
+          "revision": "f703f8d308825fb8599eb5041aed32a002c0c1bf",
           "version": null
         }
       },

--- a/Demo/SRGLetterbox-demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/SRGLetterbox-demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -86,9 +86,9 @@
         "package": "SRGAnalytics",
         "repositoryURL": "https://github.com/SRGSSR/srganalytics-apple.git",
         "state": {
-          "branch": "feature/62-update-to-tag-commander-v5",
-          "revision": "7ab0afa3dcb4f0677030b78ad6397726854dfebf",
-          "version": null
+          "branch": null,
+          "revision": "5b42f334290ee3268f61b62d02e509ec74f4a721",
+          "version": "9.0.0"
         }
       },
       {

--- a/Demo/SRGLetterbox-demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/SRGLetterbox-demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -77,9 +77,9 @@
         "package": "SRGAnalytics",
         "repositoryURL": "https://github.com/SRGSSR/srganalytics-apple.git",
         "state": {
-          "branch": null,
-          "revision": "c92014ca8838ad3cf403735ce25757afb04cd31f",
-          "version": "8.2.0"
+          "branch": "feature/62-update-to-tag-commander-v5",
+          "revision": "349803c4ea4b07e9fdc9c277bf7e6481bbf5cd55",
+          "version": null
         }
       },
       {
@@ -159,17 +159,17 @@
         "repositoryURL": "https://github.com/SRGSSR/TCCore-xcframework-apple.git",
         "state": {
           "branch": null,
-          "revision": "eb686883e63af28174472a09eda97acf07179c88",
-          "version": "4.5.4-srg5"
+          "revision": "6f5e24bed11558da8c1479157ec74a0485443834",
+          "version": "5.1.1"
         }
       },
       {
-        "package": "TCSDK",
-        "repositoryURL": "https://github.com/SRGSSR/TCSDK-xcframework-apple.git",
+        "package": "TCServerSide",
+        "repositoryURL": "https://github.com/SRGSSR/TCServerSide-xcframework-apple.git",
         "state": {
           "branch": null,
-          "revision": "c4becb0b250258b78cb46225af5e269da834db5a",
-          "version": "4.4.1-srg5"
+          "revision": "bb47eef2a14d486aa72896abc8d911fe9aed67d0",
+          "version": "5.1.2"
         }
       },
       {

--- a/Demo/SRGLetterbox-demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/SRGLetterbox-demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/CommandersAct/iOSV5.git",
         "state": {
           "branch": null,
-          "revision": "a92022d04e838f8db41dd2088169d2102bcc5cc0",
-          "version": "5.2.2"
+          "revision": "06866c11d32ed17299a290567f2cb2d82899ea00",
+          "version": "5.3.1"
         }
       },
       {
@@ -87,7 +87,7 @@
         "repositoryURL": "https://github.com/SRGSSR/srganalytics-apple.git",
         "state": {
           "branch": "feature/62-update-to-tag-commander-v5",
-          "revision": "e7264b7b182385cdc369db53cd4e8da90fc71918",
+          "revision": "c41eaf5cac36f711eb46d7224f238529f52e76ab",
           "version": null
         }
       },

--- a/Demo/SRGLetterbox-demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/SRGLetterbox-demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -87,7 +87,7 @@
         "repositoryURL": "https://github.com/SRGSSR/srganalytics-apple.git",
         "state": {
           "branch": "feature/62-update-to-tag-commander-v5",
-          "revision": "f703f8d308825fb8599eb5041aed32a002c0c1bf",
+          "revision": "7ab0afa3dcb4f0677030b78ad6397726854dfebf",
           "version": null
         }
       },

--- a/Demo/SRGLetterbox-demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/SRGLetterbox-demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -29,6 +29,15 @@
         }
       },
       {
+        "package": "TagCommander SDK V5",
+        "repositoryURL": "https://github.com/CommandersAct/iOSV5.git",
+        "state": {
+          "branch": null,
+          "revision": "804f8d04acf4556820341f02b8b5e657a060ed1f",
+          "version": "5.2.1"
+        }
+      },
+      {
         "package": "libextobjc",
         "repositoryURL": "https://github.com/SRGSSR/libextobjc.git",
         "state": {
@@ -78,7 +87,7 @@
         "repositoryURL": "https://github.com/SRGSSR/srganalytics-apple.git",
         "state": {
           "branch": "feature/62-update-to-tag-commander-v5",
-          "revision": "349803c4ea4b07e9fdc9c277bf7e6481bbf5cd55",
+          "revision": "e2643601c199c06c5ceb8f48aee159fec9437c21",
           "version": null
         }
       },
@@ -152,24 +161,6 @@
           "branch": null,
           "revision": "153a2544391c1aaccae2d38d8b113fd0a03421b8",
           "version": "3.1.0"
-        }
-      },
-      {
-        "package": "TCCore",
-        "repositoryURL": "https://github.com/SRGSSR/TCCore-xcframework-apple.git",
-        "state": {
-          "branch": null,
-          "revision": "6f5e24bed11558da8c1479157ec74a0485443834",
-          "version": "5.1.1"
-        }
-      },
-      {
-        "package": "TCServerSide",
-        "repositoryURL": "https://github.com/SRGSSR/TCServerSide-xcframework-apple.git",
-        "state": {
-          "branch": null,
-          "revision": "bb47eef2a14d486aa72896abc8d911fe9aed67d0",
-          "version": "5.1.2"
         }
       },
       {

--- a/Demo/SRGLetterbox-demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/SRGLetterbox-demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/CommandersAct/iOSV5.git",
         "state": {
           "branch": null,
-          "revision": "804f8d04acf4556820341f02b8b5e657a060ed1f",
-          "version": "5.2.1"
+          "revision": "a92022d04e838f8db41dd2088169d2102bcc5cc0",
+          "version": "5.2.2"
         }
       },
       {
@@ -87,7 +87,7 @@
         "repositoryURL": "https://github.com/SRGSSR/srganalytics-apple.git",
         "state": {
           "branch": "feature/62-update-to-tag-commander-v5",
-          "revision": "e2643601c199c06c5ceb8f48aee159fec9437c21",
+          "revision": "e7264b7b182385cdc369db53cd4e8da90fc71918",
           "version": null
         }
       },

--- a/Demo/SRGLetterbox-demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/SRGLetterbox-demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/CommandersAct/iOSV5.git",
         "state": {
           "branch": null,
-          "revision": "06866c11d32ed17299a290567f2cb2d82899ea00",
-          "version": "5.3.1"
+          "revision": "b76b700d92c35f02a3d977e7707ecf4df4732b35",
+          "version": "5.3.2"
         }
       },
       {
@@ -87,7 +87,7 @@
         "repositoryURL": "https://github.com/SRGSSR/srganalytics-apple.git",
         "state": {
           "branch": "feature/62-update-to-tag-commander-v5",
-          "revision": "c41eaf5cac36f711eb46d7224f238529f52e76ab",
+          "revision": "e4b666ff0242b94e8163dcad510a99ede1015be4",
           "version": null
         }
       },

--- a/Demo/Sources/Application/AppDelegate.m
+++ b/Demo/Sources/Application/AppDelegate.m
@@ -48,10 +48,9 @@ static __attribute__((constructor)) void ApplicationInit(void)
     // Use test setup and pre-production mode since there will never be any public App Store version of this demo application.
     // This prevents tvOS builds delivered with TestFlight from sending production data.
     SRGAnalyticsConfiguration *configuration = [[SRGAnalyticsConfiguration alloc] initWithBusinessUnitIdentifier:SRGAnalyticsBusinessUnitIdentifierRTS
-                                                                                                       container:10
+                                                                                                       sourceKey:@"39ae8f94-595c-4ca4-81f7-fb7748bd3f04"
                                                                                                         siteName:@"rts-app-test-v"];
     configuration.centralized = YES;
-    configuration.environmentMode = SRGAnalyticsEnvironmentModePreProduction;
     
     [[SRGAnalyticsTracker sharedTracker] startWithConfiguration:configuration];
     

--- a/Demo/Sources/Application/AppDelegate.m
+++ b/Demo/Sources/Application/AppDelegate.m
@@ -46,9 +46,9 @@ static __attribute__((constructor)) void ApplicationInit(void)
 #endif
     
     // Use a debug source key since there will never be any public App Store version of this demo application.
-    SRGAnalyticsConfiguration *configuration = [[SRGAnalyticsConfiguration alloc] initWithBusinessUnitIdentifier:SRGAnalyticsBusinessUnitIdentifierRTS
+    SRGAnalyticsConfiguration *configuration = [[SRGAnalyticsConfiguration alloc] initWithBusinessUnitIdentifier:SRGAnalyticsBusinessUnitIdentifierSRG
                                                                                                        sourceKey:@"39ae8f94-595c-4ca4-81f7-fb7748bd3f04"
-                                                                                                        siteName:@"rts-app-test-v"];
+                                                                                                        siteName:@"srg-app-letterbox-apple"];
     configuration.centralized = YES;
     
     [[SRGAnalyticsTracker sharedTracker] startWithConfiguration:configuration];

--- a/Demo/Sources/Application/AppDelegate.m
+++ b/Demo/Sources/Application/AppDelegate.m
@@ -45,8 +45,7 @@ static __attribute__((constructor)) void ApplicationInit(void)
     SRGLetterboxService.sharedService.mirroredOnExternalScreen = ApplicationSettingIsMirroredOnExternalScreen();
 #endif
     
-    // Use test setup and pre-production mode since there will never be any public App Store version of this demo application.
-    // This prevents tvOS builds delivered with TestFlight from sending production data.
+    // Use a debug source key since there will never be any public App Store version of this demo application.
     SRGAnalyticsConfiguration *configuration = [[SRGAnalyticsConfiguration alloc] initWithBusinessUnitIdentifier:SRGAnalyticsBusinessUnitIdentifierRTS
                                                                                                        sourceKey:@"39ae8f94-595c-4ca4-81f7-fb7748bd3f04"
                                                                                                         siteName:@"rts-app-test-v"];

--- a/Demo/Sources/Demos/AdvancedPlayerViewController.h
+++ b/Demo/Sources/Demos/AdvancedPlayerViewController.h
@@ -11,7 +11,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 API_UNAVAILABLE(tvos)
-@interface AdvancedPlayerViewController : UIViewController <SRGLetterboxPictureInPictureDelegate, SRGLetterboxViewDelegate, UIGestureRecognizerDelegate, UIViewControllerTransitioningDelegate>
+@interface AdvancedPlayerViewController : UIViewController <SRGAnalyticsViewTracking, SRGLetterboxPictureInPictureDelegate, SRGLetterboxViewDelegate, UIGestureRecognizerDelegate, UIViewControllerTransitioningDelegate>
 
 // If `media` is set, `URN` is ignored.
 - (instancetype)initWithURN:(nullable NSString *)URN media:(nullable SRGMedia *)media serviceURL:(nullable NSURL *)serviceURL;

--- a/Demo/Sources/Demos/AdvancedPlayerViewController~ios.m
+++ b/Demo/Sources/Demos/AdvancedPlayerViewController~ios.m
@@ -314,12 +314,12 @@
 
 - (void)letterboxDidStartPictureInPicture
 {
-    [[SRGAnalyticsTracker sharedTracker] trackHiddenEventWithName:@"pip_start"];
+    [[SRGAnalyticsTracker sharedTracker] trackEventWithName:@"pip_start"];
 }
 
 - (void)letterboxDidEndPictureInPicture
 {
-    [[SRGAnalyticsTracker sharedTracker] trackHiddenEventWithName:@"pip_end"];
+    [[SRGAnalyticsTracker sharedTracker] trackEventWithName:@"pip_end"];
 }
 
 - (void)letterboxDidStopPlaybackFromPictureInPicture

--- a/Demo/Sources/Demos/AdvancedPlayerViewController~ios.m
+++ b/Demo/Sources/Demos/AdvancedPlayerViewController~ios.m
@@ -290,6 +290,18 @@
     self.URNLabel.text = media.URN;
 }
 
+#pragma mark SRGAnalyticsViewTracking protocol
+
+- (NSString *)srg_pageViewTitle
+{
+    return @"Advanced Player";
+}
+
+- (NSString *)srg_pageViewType
+{
+    return @"Detail";
+}
+
 #pragma mark SRGLetterboxPictureInPictureDelegate protocol
 
 - (BOOL)letterboxDismissUserInterfaceForPictureInPicture

--- a/Demo/Sources/Demos/FeedsViewController.h
+++ b/Demo/Sources/Demos/FeedsViewController.h
@@ -4,6 +4,7 @@
 //  License information is available from the LICENSE file.
 //
 
+@import SRGAnalytics;
 @import UIKit;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -27,7 +28,7 @@ typedef API_UNAVAILABLE(tvos) NS_ENUM(NSInteger, Feed) {
 };
 
 API_UNAVAILABLE(tvos)
-@interface FeedsViewController : UIViewController <UITableViewDataSource, UITableViewDelegate>
+@interface FeedsViewController : UIViewController <SRGAnalyticsViewTracking, UITableViewDataSource, UITableViewDelegate>
 
 @property (nonatomic) Feed feed;
 

--- a/Demo/Sources/Demos/FeedsViewController~ios.m
+++ b/Demo/Sources/Demos/FeedsViewController~ios.m
@@ -152,6 +152,18 @@
     }
 }
 
+#pragma mark SRGAnalyticsViewTracking protocol
+
+- (NSString *)srg_pageViewTitle
+{
+    return @"Feeds";
+}
+
+- (NSString *)srg_pageViewType
+{
+    return @"Detail";
+}
+
 #pragma mark UITableViewDataSource protocol
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section

--- a/Demo/Sources/Demos/ListsViewController.h
+++ b/Demo/Sources/Demos/ListsViewController.h
@@ -4,11 +4,12 @@
 //  License information is available from the LICENSE file.
 //
 
+@import SRGAnalytics;
 @import UIKit;
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface ListsViewController : UITableViewController
+@interface ListsViewController : UITableViewController <SRGAnalyticsViewTracking>
 
 @end
 

--- a/Demo/Sources/Demos/ListsViewController.m
+++ b/Demo/Sources/Demos/ListsViewController.m
@@ -36,6 +36,18 @@
 #endif
 }
 
+#pragma mark SRGAnalyticsViewTracking protocol
+
+- (NSString *)srg_pageViewTitle
+{
+    return @"Lists";
+}
+
+- (NSString *)srg_pageViewType
+{
+    return @"LandingPage";
+}
+
 #pragma mark UITableViewDataSource protocol
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView

--- a/Demo/Sources/Demos/MediaListViewController.h
+++ b/Demo/Sources/Demos/MediaListViewController.h
@@ -4,6 +4,7 @@
 //  License information is available from the LICENSE file.
 //
 
+@import SRGAnalytics;
 @import SRGDataProviderModel;
 @import UIKit;
 
@@ -175,7 +176,7 @@ typedef NS_ENUM(NSInteger, MediaList) {
     MediaListLiveWebRTR
 };
 
-@interface MediaListViewController : UITableViewController
+@interface MediaListViewController : UITableViewController <SRGAnalyticsViewTracking>
 
 - (instancetype)initWithMediaList:(MediaList)mediaList topic:(nullable SRGTopic *)topic serviceURL:(nullable NSURL *)serviceURL;
 

--- a/Demo/Sources/Demos/MediaListViewController.m
+++ b/Demo/Sources/Demos/MediaListViewController.m
@@ -348,6 +348,18 @@
     self.request = request;
 }
 
+#pragma mark SRGAnalyticsViewTracking protocol
+
+- (NSString *)srg_pageViewTitle
+{
+    return @"Media List";
+}
+
+- (NSString *)srg_pageViewType
+{
+    return @"Overview";
+}
+
 #pragma mark UITableViewDataSource protocol
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section

--- a/Demo/Sources/Demos/MediasViewController.h
+++ b/Demo/Sources/Demos/MediasViewController.h
@@ -4,11 +4,12 @@
 //  License information is available from the LICENSE file.
 //
 
+@import SRGAnalytics;
 @import UIKit;
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface MediasViewController : UITableViewController
+@interface MediasViewController : UITableViewController <SRGAnalyticsViewTracking>
 
 @end
 

--- a/Demo/Sources/Demos/MediasViewController.m
+++ b/Demo/Sources/Demos/MediasViewController.m
@@ -62,6 +62,18 @@
     [self presentViewController:alertController animated:YES completion:nil];
 }
 
+#pragma mark SRGAnalyticsViewTracking protocol
+
+- (NSString *)srg_pageViewTitle
+{
+    return @"Medias";
+}
+
+- (NSString *)srg_pageViewType
+{
+    return @"LandingPage";
+}
+
 #pragma mark UITableViewDataSource protocol
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView

--- a/Demo/Sources/Demos/MiscellaneousViewController.h
+++ b/Demo/Sources/Demos/MiscellaneousViewController.h
@@ -4,12 +4,13 @@
 //  License information is available from the LICENSE file.
 //
 
+@import SRGAnalytics;
 @import UIKit;
 
 NS_ASSUME_NONNULL_BEGIN
 
 API_UNAVAILABLE(tvos)
-@interface MiscellaneousViewController : UITableViewController
+@interface MiscellaneousViewController : UITableViewController <SRGAnalyticsViewTracking>
 
 @end
 

--- a/Demo/Sources/Demos/MiscellaneousViewController~ios.m
+++ b/Demo/Sources/Demos/MiscellaneousViewController~ios.m
@@ -120,6 +120,18 @@
     [self.navigationController pushViewController:pageViewController animated:YES];
 }
 
+#pragma mark SRGAnalyticsViewTracking protocol
+
+- (NSString *)srg_pageViewTitle
+{
+    return @"Miscellaneous";
+}
+
+- (NSString *)srg_pageViewType
+{
+    return @"LandingPage";
+}
+
 #pragma mark UITableViewDataSource protocol
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView

--- a/Demo/Sources/Demos/MultiPlayerViewController.h
+++ b/Demo/Sources/Demos/MultiPlayerViewController.h
@@ -10,7 +10,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 API_UNAVAILABLE(tvos)
-@interface MultiPlayerViewController : UIViewController <SRGLetterboxPictureInPictureDelegate, SRGLetterboxViewDelegate>
+@interface MultiPlayerViewController : UIViewController <SRGAnalyticsViewTracking, SRGLetterboxPictureInPictureDelegate, SRGLetterboxViewDelegate>
 
 - (instancetype)initWithURN:(nullable NSString *)URN URN1:(nullable NSString *)URN1 URN2:(nullable NSString *)URN2 userInterfaceAlwaysHidden:(BOOL)userInterfaceAlwaysHidden;
 

--- a/Demo/Sources/Demos/MultiPlayerViewController~ios.m
+++ b/Demo/Sources/Demos/MultiPlayerViewController~ios.m
@@ -179,12 +179,12 @@
 
 - (void)letterboxDidStartPictureInPicture
 {
-    [[SRGAnalyticsTracker sharedTracker] trackHiddenEventWithName:@"pip_start"];
+    [[SRGAnalyticsTracker sharedTracker] trackEventWithName:@"pip_start"];
 }
 
 - (void)letterboxDidEndPictureInPicture
 {
-    [[SRGAnalyticsTracker sharedTracker] trackHiddenEventWithName:@"pip_end"];
+    [[SRGAnalyticsTracker sharedTracker] trackEventWithName:@"pip_end"];
 }
 
 - (void)letterboxDidStopPlaybackFromPictureInPicture

--- a/Demo/Sources/Demos/MultiPlayerViewController~ios.m
+++ b/Demo/Sources/Demos/MultiPlayerViewController~ios.m
@@ -155,6 +155,18 @@
     return YES;
 }
 
+#pragma mark SRGAnalyticsViewTracking protocol
+
+- (NSString *)srg_pageViewTitle
+{
+    return @"Multi Player";
+}
+
+- (NSString *)srg_pageViewType
+{
+    return @"Detail";
+}
+
 #pragma mark SRGLetterboxPictureInPictureDelegate protocol
 
 - (BOOL)letterboxDismissUserInterfaceForPictureInPicture

--- a/Demo/Sources/Demos/PlayerPageViewController.h
+++ b/Demo/Sources/Demos/PlayerPageViewController.h
@@ -4,12 +4,13 @@
 //  License information is available from the LICENSE file.
 //
 
+@import SRGAnalytics;
 @import UIKit;
 
 NS_ASSUME_NONNULL_BEGIN
 
 API_UNAVAILABLE(tvos)
-@interface PlayerPageViewController : UIViewController
+@interface PlayerPageViewController : UIViewController <SRGAnalyticsViewTracking>
 
 - (instancetype)initWithURN:(NSString *)URN;
 

--- a/Demo/Sources/Demos/PlayerPageViewController~ios.m
+++ b/Demo/Sources/Demos/PlayerPageViewController~ios.m
@@ -91,6 +91,18 @@
     return self.letterboxView.userInterfaceHidden;
 }
 
+#pragma mark SRGAnalyticsViewTracking protocol
+
+- (NSString *)srg_pageViewTitle
+{
+    return @"Page Navigation Player";
+}
+
+- (NSString *)srg_pageViewType
+{
+    return @"Detail";
+}
+
 #pragma mark SRGLetterboxViewDelegate protocol
 
 - (void)letterboxViewWillAnimateUserInterface:(SRGLetterboxView *)letterboxView

--- a/Demo/Sources/Demos/PlaylistViewController.h
+++ b/Demo/Sources/Demos/PlaylistViewController.h
@@ -11,7 +11,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 API_UNAVAILABLE(tvos)
-@interface PlaylistViewController : UIViewController <SRGLetterboxPictureInPictureDelegate, SRGLetterboxViewDelegate>
+@interface PlaylistViewController : UIViewController <SRGAnalyticsViewTracking, SRGLetterboxPictureInPictureDelegate, SRGLetterboxViewDelegate>
 
 - (instancetype)initWithMedias:(nullable NSArray<SRGMedia *> *)medias sourceUid:(nullable NSString *)sourceUid;
 

--- a/Demo/Sources/Demos/PlaylistViewController~ios.m
+++ b/Demo/Sources/Demos/PlaylistViewController~ios.m
@@ -143,6 +143,18 @@
     }];
 }
 
+#pragma mark SRGAnalyticsViewTracking protocol
+
+- (NSString *)srg_pageViewTitle
+{
+    return @"Playlist";
+}
+
+- (NSString *)srg_pageViewType
+{
+    return @"Overview";
+}
+
 #pragma mark SRGLetterboxPictureInPictureDelegate protocol
 
 - (BOOL)letterboxDismissUserInterfaceForPictureInPicture

--- a/Demo/Sources/Demos/PlaylistViewController~ios.m
+++ b/Demo/Sources/Demos/PlaylistViewController~ios.m
@@ -172,12 +172,12 @@
 
 - (void)letterboxDidStartPictureInPicture
 {
-    [[SRGAnalyticsTracker sharedTracker] trackHiddenEventWithName:@"pip_start"];
+    [[SRGAnalyticsTracker sharedTracker] trackEventWithName:@"pip_start"];
 }
 
 - (void)letterboxDidEndPictureInPicture
 {
-    [[SRGAnalyticsTracker sharedTracker] trackHiddenEventWithName:@"pip_end"];
+    [[SRGAnalyticsTracker sharedTracker] trackEventWithName:@"pip_end"];
 }
 
 #pragma mark SRGLetterboxViewDelegate protocol

--- a/Demo/Sources/Demos/SettingsViewController.h
+++ b/Demo/Sources/Demos/SettingsViewController.h
@@ -6,6 +6,7 @@
 
 #include "ServerSettings.h"
 
+@import SRGAnalytics;
 @import SRGDataProviderModel;
 @import UIKit;
 
@@ -29,7 +30,7 @@ OBJC_EXPORT NSTimeInterval const LetterboxDemoSettingUpdateIntervalShort;
 OBJC_EXPORT API_UNAVAILABLE(tvos) BOOL ApplicationSettingIsBackgroundVideoPlaybackEnabled(void);
 OBJC_EXPORT BOOL ApplicationSettingPrefersMediaContentEnabled(void);
 
-@interface SettingsViewController : UITableViewController
+@interface SettingsViewController : UITableViewController <SRGAnalyticsViewTracking>
 
 @end
 

--- a/Demo/Sources/Demos/SettingsViewController.m
+++ b/Demo/Sources/Demos/SettingsViewController.m
@@ -275,6 +275,18 @@ NSDictionary<NSString *, NSString *> *ApplicationSettingGlobalParameters(void)
     [cache.diskCache removeAllObjects];
 }
 
+#pragma mark SRGAnalyticsViewTracking protocol
+
+- (NSString *)srg_pageViewTitle
+{
+    return @"Settings";
+}
+
+- (NSString *)srg_pageViewType
+{
+    return @"LandingPage";
+}
+
 #pragma mark UITableViewDataSource protocol
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView

--- a/Demo/Sources/Demos/SimplePlayerViewController.h
+++ b/Demo/Sources/Demos/SimplePlayerViewController.h
@@ -4,12 +4,13 @@
 //  License information is available from the LICENSE file.
 //
 
+@import SRGAnalytics;
 @import UIKit;
 
 NS_ASSUME_NONNULL_BEGIN
 
 API_UNAVAILABLE(tvos)
-@interface SimplePlayerViewController : UIViewController
+@interface SimplePlayerViewController : UIViewController <SRGAnalyticsViewTracking>
 
 - (instancetype)initWithURN:(nullable NSString *)URN;
 

--- a/Demo/Sources/Demos/SimplePlayerViewController~ios.m
+++ b/Demo/Sources/Demos/SimplePlayerViewController~ios.m
@@ -91,6 +91,18 @@
     return YES;
 }
 
+#pragma mark SRGAnalyticsViewTracking protocol
+
+- (NSString *)srg_pageViewTitle
+{
+    return @"Simple Player";
+}
+
+- (NSString *)srg_pageViewType
+{
+    return @"Detail";
+}
+
 #pragma mark SRGLetterboxViewDelegate protocol
 
 - (void)letterboxViewWillAnimateUserInterface:(SRGLetterboxView *)letterboxView

--- a/Demo/Sources/Demos/StandalonePlayerViewController.h
+++ b/Demo/Sources/Demos/StandalonePlayerViewController.h
@@ -11,7 +11,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 API_UNAVAILABLE(tvos)
-@interface StandalonePlayerViewController : UIViewController <SRGLetterboxPictureInPictureDelegate, SRGLetterboxViewDelegate>
+@interface StandalonePlayerViewController : UIViewController <SRGAnalyticsViewTracking, SRGLetterboxPictureInPictureDelegate, SRGLetterboxViewDelegate>
 
 - (instancetype)initWithURN:(nullable NSString *)URN;
 

--- a/Demo/Sources/Demos/StandalonePlayerViewController~ios.m
+++ b/Demo/Sources/Demos/StandalonePlayerViewController~ios.m
@@ -114,6 +114,18 @@
     return YES;
 }
 
+#pragma mark SRGAnalyticsViewTracking protocol
+
+- (NSString *)srg_pageViewTitle
+{
+    return @"Standalone Player";
+}
+
+- (NSString *)srg_pageViewType
+{
+    return @"Detail";
+}
+
 #pragma mark SRGLetterboxPictureInPictureDelegate protocol
 
 - (BOOL)letterboxDismissUserInterfaceForPictureInPicture

--- a/Demo/Sources/Demos/StandalonePlayerViewController~ios.m
+++ b/Demo/Sources/Demos/StandalonePlayerViewController~ios.m
@@ -138,12 +138,12 @@
 
 - (void)letterboxDidStartPictureInPicture
 {
-    [[SRGAnalyticsTracker sharedTracker] trackHiddenEventWithName:@"pip_start"];
+    [[SRGAnalyticsTracker sharedTracker] trackEventWithName:@"pip_start"];
 }
 
 - (void)letterboxDidEndPictureInPicture
 {
-    [[SRGAnalyticsTracker sharedTracker] trackHiddenEventWithName:@"pip_end"];
+    [[SRGAnalyticsTracker sharedTracker] trackEventWithName:@"pip_end"];
 }
 
 - (void)letterboxDidStopPlaybackFromPictureInPicture

--- a/Demo/Sources/Demos/TopicListViewController.h
+++ b/Demo/Sources/Demos/TopicListViewController.h
@@ -4,6 +4,7 @@
 //  License information is available from the LICENSE file.
 //
 
+@import SRGAnalytics;
 @import UIKit;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -42,7 +43,7 @@ typedef NS_ENUM(NSInteger, TopicList) {
     TopicListMMF
 };
 
-@interface TopicListViewController : UITableViewController
+@interface TopicListViewController : UITableViewController <SRGAnalyticsViewTracking>
 
 - (instancetype)initWithTopicList:(TopicList)topicList;
 

--- a/Demo/Sources/Demos/TopicListViewController.m
+++ b/Demo/Sources/Demos/TopicListViewController.m
@@ -145,6 +145,18 @@
     return vendorNumber.integerValue;
 }
 
+#pragma mark SRGAnalyticsViewTracking protocol
+
+- (NSString *)srg_pageViewTitle
+{
+    return @"Topic List";
+}
+
+- (NSString *)srg_pageViewType
+{
+    return @"Overview";
+}
+
 #pragma mark UITableViewDataSource protocol
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/CommandersAct/iOSV5.git",
         "state": {
           "branch": null,
-          "revision": "b76b700d92c35f02a3d977e7707ecf4df4732b35",
-          "version": "5.3.2"
+          "revision": "2e56e97db76d55657d0dc7d13e2fcd81ce4eaa6c",
+          "version": "5.3.3"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -69,7 +69,7 @@
         "repositoryURL": "https://github.com/SRGSSR/srganalytics-apple.git",
         "state": {
           "branch": "feature/62-update-to-tag-commander-v5",
-          "revision": "f703f8d308825fb8599eb5041aed32a002c0c1bf",
+          "revision": "7ab0afa3dcb4f0677030b78ad6397726854dfebf",
           "version": null
         }
       },

--- a/Package.resolved
+++ b/Package.resolved
@@ -68,9 +68,9 @@
         "package": "SRGAnalytics",
         "repositoryURL": "https://github.com/SRGSSR/srganalytics-apple.git",
         "state": {
-          "branch": "feature/62-update-to-tag-commander-v5",
-          "revision": "7ab0afa3dcb4f0677030b78ad6397726854dfebf",
-          "version": null
+          "branch": null,
+          "revision": "5b42f334290ee3268f61b62d02e509ec74f4a721",
+          "version": "9.0.0"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/CommandersAct/iOSV5.git",
         "state": {
           "branch": null,
-          "revision": "804f8d04acf4556820341f02b8b5e657a060ed1f",
-          "version": "5.2.1"
+          "revision": "a92022d04e838f8db41dd2088169d2102bcc5cc0",
+          "version": "5.2.2"
         }
       },
       {
@@ -69,7 +69,7 @@
         "repositoryURL": "https://github.com/SRGSSR/srganalytics-apple.git",
         "state": {
           "branch": "feature/62-update-to-tag-commander-v5",
-          "revision": "e2643601c199c06c5ceb8f48aee159fec9437c21",
+          "revision": "e7264b7b182385cdc369db53cd4e8da90fc71918",
           "version": null
         }
       },

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/CommandersAct/iOSV5.git",
         "state": {
           "branch": null,
-          "revision": "a92022d04e838f8db41dd2088169d2102bcc5cc0",
-          "version": "5.2.2"
+          "revision": "06866c11d32ed17299a290567f2cb2d82899ea00",
+          "version": "5.3.1"
         }
       },
       {
@@ -69,7 +69,7 @@
         "repositoryURL": "https://github.com/SRGSSR/srganalytics-apple.git",
         "state": {
           "branch": "feature/62-update-to-tag-commander-v5",
-          "revision": "e7264b7b182385cdc369db53cd4e8da90fc71918",
+          "revision": "c41eaf5cac36f711eb46d7224f238529f52e76ab",
           "version": null
         }
       },

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/CommandersAct/iOSV5.git",
         "state": {
           "branch": null,
-          "revision": "06866c11d32ed17299a290567f2cb2d82899ea00",
-          "version": "5.3.1"
+          "revision": "b76b700d92c35f02a3d977e7707ecf4df4732b35",
+          "version": "5.3.2"
         }
       },
       {
@@ -69,7 +69,7 @@
         "repositoryURL": "https://github.com/SRGSSR/srganalytics-apple.git",
         "state": {
           "branch": "feature/62-update-to-tag-commander-v5",
-          "revision": "c41eaf5cac36f711eb46d7224f238529f52e76ab",
+          "revision": "e4b666ff0242b94e8163dcad510a99ede1015be4",
           "version": null
         }
       },

--- a/Package.resolved
+++ b/Package.resolved
@@ -20,6 +20,15 @@
         }
       },
       {
+        "package": "TagCommander SDK V5",
+        "repositoryURL": "https://github.com/CommandersAct/iOSV5.git",
+        "state": {
+          "branch": null,
+          "revision": "804f8d04acf4556820341f02b8b5e657a060ed1f",
+          "version": "5.2.1"
+        }
+      },
+      {
         "package": "libextobjc",
         "repositoryURL": "https://github.com/SRGSSR/libextobjc.git",
         "state": {
@@ -60,7 +69,7 @@
         "repositoryURL": "https://github.com/SRGSSR/srganalytics-apple.git",
         "state": {
           "branch": "feature/62-update-to-tag-commander-v5",
-          "revision": "349803c4ea4b07e9fdc9c277bf7e6481bbf5cd55",
+          "revision": "e2643601c199c06c5ceb8f48aee159fec9437c21",
           "version": null
         }
       },
@@ -134,24 +143,6 @@
           "branch": null,
           "revision": "153a2544391c1aaccae2d38d8b113fd0a03421b8",
           "version": "3.1.0"
-        }
-      },
-      {
-        "package": "TCCore",
-        "repositoryURL": "https://github.com/SRGSSR/TCCore-xcframework-apple.git",
-        "state": {
-          "branch": null,
-          "revision": "6f5e24bed11558da8c1479157ec74a0485443834",
-          "version": "5.1.1"
-        }
-      },
-      {
-        "package": "TCServerSide",
-        "repositoryURL": "https://github.com/SRGSSR/TCServerSide-xcframework-apple.git",
-        "state": {
-          "branch": null,
-          "revision": "bb47eef2a14d486aa72896abc8d911fe9aed67d0",
-          "version": "5.1.2"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -59,9 +59,9 @@
         "package": "SRGAnalytics",
         "repositoryURL": "https://github.com/SRGSSR/srganalytics-apple.git",
         "state": {
-          "branch": null,
-          "revision": "c92014ca8838ad3cf403735ce25757afb04cd31f",
-          "version": "8.2.0"
+          "branch": "feature/62-update-to-tag-commander-v5",
+          "revision": "349803c4ea4b07e9fdc9c277bf7e6481bbf5cd55",
+          "version": null
         }
       },
       {
@@ -141,17 +141,17 @@
         "repositoryURL": "https://github.com/SRGSSR/TCCore-xcframework-apple.git",
         "state": {
           "branch": null,
-          "revision": "eb686883e63af28174472a09eda97acf07179c88",
-          "version": "4.5.4-srg5"
+          "revision": "6f5e24bed11558da8c1479157ec74a0485443834",
+          "version": "5.1.1"
         }
       },
       {
-        "package": "TCSDK",
-        "repositoryURL": "https://github.com/SRGSSR/TCSDK-xcframework-apple.git",
+        "package": "TCServerSide",
+        "repositoryURL": "https://github.com/SRGSSR/TCServerSide-xcframework-apple.git",
         "state": {
           "branch": null,
-          "revision": "c4becb0b250258b78cb46225af5e269da834db5a",
-          "version": "4.4.1-srg5"
+          "revision": "bb47eef2a14d486aa72896abc8d911fe9aed67d0",
+          "version": "5.1.2"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -69,7 +69,7 @@
         "repositoryURL": "https://github.com/SRGSSR/srganalytics-apple.git",
         "state": {
           "branch": "feature/62-update-to-tag-commander-v5",
-          "revision": "e4b666ff0242b94e8163dcad510a99ede1015be4",
+          "revision": "f703f8d308825fb8599eb5041aed32a002c0c1bf",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@
 import PackageDescription
 
 struct ProjectSettings {
-    static let marketingVersion = "9.1.2"
+    static let marketingVersion = "9.1.1"
 }
 
 let package = Package(
@@ -22,7 +22,7 @@ let package = Package(
     dependencies: [
         .package(name: "FXReachability", url: "https://github.com/SRGSSR/FXReachability.git", .exact("1.3.2-srg6")),
         .package(name: "OHHTTPStubs", url: "https://github.com/AliSoftware/OHHTTPStubs.git", .upToNextMajor(from: "9.0.0")),
-        .package(name: "SRGAnalytics", url: "https://github.com/SRGSSR/srganalytics-apple.git", .upToNextMinor(from: "8.2.0")),
+        .package(name: "SRGAnalytics", url: "https://github.com/SRGSSR/srganalytics-apple.git", .branch("feature/62-update-to-tag-commander-v5")),
         .package(name: "SRGAppearance", url: "https://github.com/SRGSSR/srgappearance-apple.git", .upToNextMinor(from: "5.2.0")),
         .package(name: "YYWebImage", url: "https://github.com/SRGSSR/YYWebImage.git", .exact("1.0.5-srg3"))
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
     dependencies: [
         .package(name: "FXReachability", url: "https://github.com/SRGSSR/FXReachability.git", .exact("1.3.2-srg6")),
         .package(name: "OHHTTPStubs", url: "https://github.com/AliSoftware/OHHTTPStubs.git", .upToNextMajor(from: "9.0.0")),
-        .package(name: "SRGAnalytics", url: "https://github.com/SRGSSR/srganalytics-apple.git", .branch("feature/62-update-to-tag-commander-v5")),
+        .package(name: "SRGAnalytics", url: "https://github.com/SRGSSR/srganalytics-apple.git", .upToNextMinor(from: "9.0.0")),
         .package(name: "SRGAppearance", url: "https://github.com/SRGSSR/srgappearance-apple.git", .upToNextMinor(from: "5.2.0")),
         .package(name: "YYWebImage", url: "https://github.com/SRGSSR/YYWebImage.git", .exact("1.0.5-srg3"))
     ],

--- a/Sources/SRGLetterbox/NSBundle+SRGLetterbox.h
+++ b/Sources/SRGLetterbox/NSBundle+SRGLetterbox.h
@@ -26,13 +26,4 @@ NS_ASSUME_NONNULL_BEGIN
 __attribute__((annotate("returns_localized_nsstring")))
 OBJC_EXPORT NSString *SRGLetterboxNonLocalizedString(NSString *string);
 
-@interface NSBundle (SRGLetterbox)
-
-/**
- *  Return `YES` iff the application bundle corresponds to an AppStore or TestFlight release.
- */
-@property (class, nonatomic, readonly) BOOL srg_letterbox_isProductionVersion;
-
-@end
-
 NS_ASSUME_NONNULL_END

--- a/Sources/SRGLetterbox/NSBundle+SRGLetterbox.m
+++ b/Sources/SRGLetterbox/NSBundle+SRGLetterbox.m
@@ -12,23 +12,3 @@ NSString *SRGLetterboxNonLocalizedString(NSString *string)
 {
     return string;
 }
-
-@implementation NSBundle (SRGLetterbox)
-
-#pragma mark Class methods
-
-+ (BOOL)srg_letterbox_isProductionVersion
-{
-    if (NSProcessInfo.processInfo.environment[@"SIMULATOR_DEVICE_NAME"]
-            || [UIDevice.currentDevice.name.lowercaseString containsString:@"simulator"]) {
-        return NO;
-    }
-    
-    if ([NSBundle.mainBundle pathForResource:@"embedded" ofType:@"mobileprovision"]) {
-        return NO;
-    }
-    
-    return (NSBundle.mainBundle.appStoreReceiptURL != nil);
-}
-
-@end

--- a/Sources/SRGLetterbox/SRGLetterboxController.m
+++ b/Sources/SRGLetterbox/SRGLetterboxController.m
@@ -576,12 +576,6 @@ static SRGPlaybackSettings *SRGPlaybackSettingsFromLetterboxPlaybackSettings(SRG
     return AVAudioSession.srg_isAirPlayActive && (self.media.mediaType == SRGMediaTypeAudio || self.mediaPlayerController.player.externalPlaybackActive);
 }
 
-- (BOOL)isProductionVersion
-{
-    SRGAnalyticsConfiguration *analyticsConfiguration = SRGAnalyticsTracker.sharedTracker.configuration;
-    return analyticsConfiguration ? analyticsConfiguration.environment == SRGAnalyticsEnvironmentProduction : NSBundle.srg_letterbox_isProductionVersion;
-}
-
 - (void)setReport:(SRGDiagnosticReport *)report
 {
     [_report discard];
@@ -1640,7 +1634,6 @@ static SRGPlaybackSettings *SRGPlaybackSettingsFromLetterboxPlaybackSettings(SRG
 #else
     [report setString:[NSString stringWithFormat:@"Letterbox/iOS/%@", SRGLetterboxMarketingVersion()] forKey:@"player"];
 #endif
-    [report setString:[self isProductionVersion] ? @"prod" : @"preprod" forKey:@"environment"];
     [report setString:SRGDeviceInformation() forKey:@"device"];
     [report setString:NSBundle.mainBundle.bundleIdentifier forKey:@"browser"];
     [report setString:self.usingAirPlay ? @"airplay" : @"local" forKey:@"screenType"];

--- a/Sources/SRGLetterbox/SRGLetterboxView~ios.m
+++ b/Sources/SRGLetterbox/SRGLetterboxView~ios.m
@@ -791,11 +791,6 @@ static const CGFloat kBottomConstraintLesserPriority = 850.f;
     BOOL playerViewVisible = (self.controller.media.mediaType == SRGMediaTypeVideo && mediaPlayerController.view.readyForDisplay && ! mediaPlayerController.externalNonMirroredPlaybackActive
                               && playbackState != SRGMediaPlayerPlaybackStateIdle && playbackState != SRGMediaPlayerPlaybackStatePreparing && playbackState != SRGMediaPlayerPlaybackStateEnded);
     
-    // Prevent capture in production builds
-    if (NSBundle.srg_letterbox_isProductionVersion && UIScreen.mainScreen.captured && ! AVAudioSession.srg_isAirPlayActive) {
-        playerViewVisible = NO;
-    }
-    
     // Reset to aspect fit gravity if the updated layout does not support aspect fill anymore
     if (! [self supportsAspectFillVideoGravity]) {
         self.controller.mediaPlayerController.playerLayer.videoGravity = AVLayerVideoGravityResizeAspect;

--- a/Tests/SRGLetterboxTests/DiagnosticTestCase.m
+++ b/Tests/SRGLetterboxTests/DiagnosticTestCase.m
@@ -89,7 +89,6 @@ static NSString * const DiagnosticTestCasePlatform = @"iOS";
         XCTAssertEqualObjects(JSONDictionary[@"browser"], NSBundle.mainBundle.bundleIdentifier);
         NSString *playerName = [NSString stringWithFormat:@"Letterbox/%@/%@", DiagnosticTestCasePlatform, SRGLetterboxMarketingVersion()];
         XCTAssertEqualObjects(JSONDictionary[@"player"], playerName);
-        XCTAssertEqualObjects(JSONDictionary[@"environment"], @"preprod");
         
         XCTAssertNotNil(JSONDictionary[@"clientTime"]);
         XCTAssertNotNil(JSONDictionary[@"device"]);
@@ -161,7 +160,6 @@ static NSString * const DiagnosticTestCasePlatform = @"iOS";
         XCTAssertEqualObjects(JSONDictionary[@"browser"], NSBundle.mainBundle.bundleIdentifier);
         NSString *playerName = [NSString stringWithFormat:@"Letterbox/%@/%@", DiagnosticTestCasePlatform, SRGLetterboxMarketingVersion()];
         XCTAssertEqualObjects(JSONDictionary[@"player"], playerName);
-        XCTAssertEqualObjects(JSONDictionary[@"environment"], @"preprod");
         
         XCTAssertNotNil(JSONDictionary[@"clientTime"]);
         XCTAssertNotNil(JSONDictionary[@"device"]);
@@ -203,7 +201,6 @@ static NSString * const DiagnosticTestCasePlatform = @"iOS";
         XCTAssertEqualObjects(JSONDictionary[@"browser"], NSBundle.mainBundle.bundleIdentifier);
         NSString *playerName = [NSString stringWithFormat:@"Letterbox/%@/%@", DiagnosticTestCasePlatform, SRGLetterboxMarketingVersion()];
         XCTAssertEqualObjects(JSONDictionary[@"player"], playerName);
-        XCTAssertEqualObjects(JSONDictionary[@"environment"], @"preprod");
         
         XCTAssertNotNil(JSONDictionary[@"clientTime"]);
         XCTAssertNotNil(JSONDictionary[@"device"]);
@@ -252,7 +249,6 @@ static NSString * const DiagnosticTestCasePlatform = @"iOS";
         XCTAssertEqualObjects(JSONDictionary[@"browser"], NSBundle.mainBundle.bundleIdentifier);
         NSString *playerName = [NSString stringWithFormat:@"Letterbox/%@/%@", DiagnosticTestCasePlatform, SRGLetterboxMarketingVersion()];
         XCTAssertEqualObjects(JSONDictionary[@"player"], playerName);
-        XCTAssertEqualObjects(JSONDictionary[@"environment"], @"preprod");
         
         XCTAssertNotNil(JSONDictionary[@"clientTime"]);
         XCTAssertNotNil(JSONDictionary[@"device"]);
@@ -328,7 +324,6 @@ static NSString * const DiagnosticTestCasePlatform = @"iOS";
         XCTAssertEqualObjects(JSONDictionary[@"browser"], NSBundle.mainBundle.bundleIdentifier);
         NSString *playerName = [NSString stringWithFormat:@"Letterbox/%@/%@", DiagnosticTestCasePlatform, SRGLetterboxMarketingVersion()];
         XCTAssertEqualObjects(JSONDictionary[@"player"], playerName);
-        XCTAssertEqualObjects(JSONDictionary[@"environment"], @"preprod");
         
         XCTAssertNotNil(JSONDictionary[@"clientTime"]);
         XCTAssertNotNil(JSONDictionary[@"device"]);
@@ -623,7 +618,6 @@ static NSString * const DiagnosticTestCasePlatform = @"iOS";
         XCTAssertEqualObjects(JSONDictionary[@"browser"], NSBundle.mainBundle.bundleIdentifier);
         NSString *playerName = [NSString stringWithFormat:@"Letterbox/%@/%@", DiagnosticTestCasePlatform, SRGLetterboxMarketingVersion()];
         XCTAssertEqualObjects(JSONDictionary[@"player"], playerName);
-        XCTAssertEqualObjects(JSONDictionary[@"environment"], @"preprod");
         
         XCTAssertNotNil(JSONDictionary[@"clientTime"]);
         XCTAssertNotNil(JSONDictionary[@"device"]);
@@ -672,7 +666,6 @@ static NSString * const DiagnosticTestCasePlatform = @"iOS";
         XCTAssertEqualObjects(JSONDictionary[@"browser"], NSBundle.mainBundle.bundleIdentifier);
         NSString *playerName = [NSString stringWithFormat:@"Letterbox/%@/%@", DiagnosticTestCasePlatform, SRGLetterboxMarketingVersion()];
         XCTAssertEqualObjects(JSONDictionary[@"player"], playerName);
-        XCTAssertEqualObjects(JSONDictionary[@"environment"], @"preprod");
         
         XCTAssertNotNil(JSONDictionary[@"clientTime"]);
         XCTAssertNotNil(JSONDictionary[@"device"]);

--- a/Tests/SRGLetterboxTests/DiagnosticTestCase.m
+++ b/Tests/SRGLetterboxTests/DiagnosticTestCase.m
@@ -701,27 +701,4 @@ static NSString * const DiagnosticTestCasePlatform = @"iOS";
     [self waitForExpectationsWithTimeout:30. handler:nil];
 }
 
-- (void)testPlaybackReportForForcedAnalyticsEnvironmentMode
-{
-    NSString *URN = OnDemandVideoURN;
-    
-    SRGAnalyticsEnvironmentMode originalAnalyticsEnvironmentMode = SRGAnalyticsTracker.sharedTracker.configuration.environmentMode;
-    SRGAnalyticsTracker.sharedTracker.configuration.environmentMode = SRGAnalyticsEnvironmentModeProduction;
-    
-    [self expectationForSingleNotification:SRGLetterboxPlaybackStateDidChangeNotification object:self.controller handler:^BOOL(NSNotification * _Nonnull notification) {
-        return [notification.userInfo[SRGMediaPlayerPlaybackStateKey] integerValue] == SRGMediaPlayerPlaybackStatePlaying;
-    }];
-    [self expectationForSingleNotification:DiagnosticTestDidSendReportNotification object:nil handler:^BOOL(NSNotification * _Nonnull notification) {
-        NSDictionary *JSONDictionary = notification.userInfo[DiagnosticTestJSONDictionaryKey];
-        XCTAssertEqualObjects(JSONDictionary[@"environment"], @"prod");
-        return YES;
-    }];
-    
-    [self.controller playURN:URN atPosition:nil withPreferredSettings:nil];
-    
-    [self waitForExpectationsWithTimeout:30. handler:nil];
-    
-    SRGAnalyticsTracker.sharedTracker.configuration.environmentMode = originalAnalyticsEnvironmentMode;
-}
-
 @end

--- a/Tests/SRGLetterboxTests/DiagnosticTestCase.m
+++ b/Tests/SRGLetterboxTests/DiagnosticTestCase.m
@@ -5,6 +5,7 @@
 //
 
 #import "LetterboxBaseTestCase.h"
+#import "TrackerSingletonSetup.h"
 
 @import libextobjc;
 @import OHHTTPStubs;
@@ -33,6 +34,11 @@ static NSString * const DiagnosticTestCasePlatform = @"iOS";
 @implementation DiagnosticTestCase
 
 #pragma mark Setup and tear down
+
++ (void)setUp
+{
+    SetupTestSingletonTracker();
+}
 
 - (void)setUp
 {

--- a/Tests/SRGLetterboxTests/MetadataTestCase.m
+++ b/Tests/SRGLetterboxTests/MetadataTestCase.m
@@ -5,6 +5,7 @@
 //
 
 #import "LetterboxBaseTestCase.h"
+#import "TrackerSingletonSetup.h"
 
 @import libextobjc;
 @import SRGLetterbox;
@@ -21,6 +22,11 @@
 @implementation MetadataTestCase
 
 #pragma mark Setup and tear down
+
++ (void)setUp
+{
+    SetupTestSingletonTracker();
+}
 
 - (void)setUp
 {

--- a/Tests/SRGLetterboxTests/PlaybackTestCase.m
+++ b/Tests/SRGLetterboxTests/PlaybackTestCase.m
@@ -5,6 +5,7 @@
 //
 
 #import "LetterboxBaseTestCase.h"
+#import "TrackerSingletonSetup.h"
 
 @import libextobjc;
 @import SRGDataProviderNetwork;
@@ -22,6 +23,11 @@
 @implementation PlaybackTestCase
 
 #pragma mark Setup and tear down
+
++ (void)setUp
+{
+    SetupTestSingletonTracker();
+}
 
 - (void)setUp
 {

--- a/Tests/SRGLetterboxTests/PlaylistsTestCase.m
+++ b/Tests/SRGLetterboxTests/PlaylistsTestCase.m
@@ -6,6 +6,7 @@
 
 #import "LetterboxBaseTestCase.h"
 #import "TestPlaylist.h"
+#import "TrackerSingletonSetup.h"
 
 @import libextobjc;
 @import SRGDataProviderNetwork;
@@ -27,6 +28,11 @@ static NSString * const MediaURN2 = @"urn:rts:video:9314051";
 @implementation PlaylistsTestCase
 
 #pragma mark Setup and tear down
+
++ (void)setUp
+{
+    SetupTestSingletonTracker();
+}
 
 - (void)setUp
 {

--- a/Tests/SRGLetterboxTests/RateTestCase.m
+++ b/Tests/SRGLetterboxTests/RateTestCase.m
@@ -5,6 +5,7 @@
 //
 
 #import "LetterboxBaseTestCase.h"
+#import "TrackerSingletonSetup.h"
 
 @import libextobjc;
 @import SRGLetterbox;
@@ -18,6 +19,11 @@
 @implementation RateTestCase
 
 #pragma mark Setup and tear down
+
++ (void)setUp
+{
+    SetupTestSingletonTracker();
+}
 
 - (void)setUp
 {

--- a/Tests/SRGLetterboxTests/SkipTestCase.m
+++ b/Tests/SRGLetterboxTests/SkipTestCase.m
@@ -5,6 +5,7 @@
 //
 
 #import "LetterboxBaseTestCase.h"
+#import "TrackerSingletonSetup.h"
 
 @import SRGLetterbox;
 
@@ -17,6 +18,11 @@
 @implementation SkipTestCase
 
 #pragma mark Setup and tear down
+
++ (void)setUp
+{
+    SetupTestSingletonTracker();
+}
 
 - (void)setUp
 {

--- a/Tests/SRGLetterboxTests/SocialCountTestCase.m
+++ b/Tests/SRGLetterboxTests/SocialCountTestCase.m
@@ -5,6 +5,7 @@
 //
 
 #import "LetterboxBaseTestCase.h"
+#import "TrackerSingletonSetup.h"
 
 @import SRGLetterbox;
 
@@ -20,6 +21,11 @@
 @implementation SocialCountTestCase
 
 #pragma mark Setup and tear down
+
++ (void)setUp
+{
+    SetupTestSingletonTracker();
+}
 
 - (void)setUp
 {

--- a/Tests/SRGLetterboxTests/SourceUidTestCase.m
+++ b/Tests/SRGLetterboxTests/SourceUidTestCase.m
@@ -5,6 +5,7 @@
 //
 
 #import "LetterboxBaseTestCase.h"
+#import "TrackerSingletonSetup.h"
 
 @import SRGLetterbox;
 
@@ -23,6 +24,11 @@
 @implementation SourceUidTestCase
 
 #pragma mark Setup and tear down
+
++ (void)setUp
+{
+    SetupTestSingletonTracker();
+}
 
 - (void)setUp
 {

--- a/Tests/SRGLetterboxTests/SwissTXTTestCase.m
+++ b/Tests/SRGLetterboxTests/SwissTXTTestCase.m
@@ -5,6 +5,7 @@
 //
 
 #import "LetterboxBaseTestCase.h"
+#import "TrackerSingletonSetup.h"
 
 @import libextobjc;
 @import SRGLetterbox;
@@ -21,6 +22,11 @@
 @implementation SwissTXTTestCase
 
 #pragma mark Setup and tear down
+
++ (void)setUp
+{
+    SetupTestSingletonTracker();
+}
 
 - (void)setUp
 {

--- a/Tests/SRGLetterboxTests/SwitchTestCase.m
+++ b/Tests/SRGLetterboxTests/SwitchTestCase.m
@@ -5,6 +5,7 @@
 //
 
 #import "LetterboxBaseTestCase.h"
+#import "TrackerSingletonSetup.h"
 
 @import SRGDataProviderNetwork;
 @import SRGLetterbox;
@@ -18,6 +19,11 @@
 @implementation SwitchTestCase
 
 #pragma mark Setup and tear down
+
++ (void)setUp
+{
+    SetupTestSingletonTracker();
+}
 
 - (void)setUp
 {

--- a/Tests/SRGLetterboxTests/TrackerSingletonSetup.h
+++ b/Tests/SRGLetterboxTests/TrackerSingletonSetup.h
@@ -1,0 +1,13 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+@import Foundation;
+
+NS_ASSUME_NONNULL_BEGIN
+
+OBJC_EXPORT void SetupTestSingletonTracker(void);
+
+NS_ASSUME_NONNULL_END

--- a/Tests/SRGLetterboxTests/TrackerSingletonSetup.m
+++ b/Tests/SRGLetterboxTests/TrackerSingletonSetup.m
@@ -9,8 +9,8 @@
 // The singleton can be only setup once. Do not perform in a test case setup
 __attribute__((constructor)) static void SetupTestSingletonTracker(void)
 {
-    SRGAnalyticsConfiguration *configuration = [[SRGAnalyticsConfiguration alloc] initWithBusinessUnitIdentifier:SRGAnalyticsBusinessUnitIdentifierRTS
+    SRGAnalyticsConfiguration *configuration = [[SRGAnalyticsConfiguration alloc] initWithBusinessUnitIdentifier:SRGAnalyticsBusinessUnitIdentifierSRG
                                                                                                        sourceKey:@"39ae8f94-595c-4ca4-81f7-fb7748bd3f04"
-                                                                                                        siteName:@"rts-app-test-v"];
+                                                                                                        siteName:@"srg-test-letterbox-apple"];
     [SRGAnalyticsTracker.sharedTracker startWithConfiguration:configuration];
 }

--- a/Tests/SRGLetterboxTests/TrackerSingletonSetup.m
+++ b/Tests/SRGLetterboxTests/TrackerSingletonSetup.m
@@ -10,7 +10,7 @@
 __attribute__((constructor)) static void SetupTestSingletonTracker(void)
 {
     SRGAnalyticsConfiguration *configuration = [[SRGAnalyticsConfiguration alloc] initWithBusinessUnitIdentifier:SRGAnalyticsBusinessUnitIdentifierRTS
-                                                                                                       container:7
+                                                                                                       sourceKey:@"39ae8f94-595c-4ca4-81f7-fb7748bd3f04"
                                                                                                         siteName:@"rts-app-test-v"];
     [SRGAnalyticsTracker.sharedTracker startWithConfiguration:configuration];
 }

--- a/Tests/SRGLetterboxTests/TrackerSingletonSetup.m
+++ b/Tests/SRGLetterboxTests/TrackerSingletonSetup.m
@@ -6,7 +6,6 @@
 
 @import SRGAnalytics;
 
-// The singleton can be only setup once. Do not perform in a test case setup
 void SetupTestSingletonTracker(void)
 {
     SRGAnalyticsConfiguration *configuration = [[SRGAnalyticsConfiguration alloc] initWithBusinessUnitIdentifier:SRGAnalyticsBusinessUnitIdentifierSRG

--- a/Tests/SRGLetterboxTests/TrackerSingletonSetup.m
+++ b/Tests/SRGLetterboxTests/TrackerSingletonSetup.m
@@ -7,10 +7,11 @@
 @import SRGAnalytics;
 
 // The singleton can be only setup once. Do not perform in a test case setup
-__attribute__((constructor)) static void SetupTestSingletonTracker(void)
+void SetupTestSingletonTracker(void)
 {
     SRGAnalyticsConfiguration *configuration = [[SRGAnalyticsConfiguration alloc] initWithBusinessUnitIdentifier:SRGAnalyticsBusinessUnitIdentifierSRG
                                                                                                        sourceKey:@"39ae8f94-595c-4ca4-81f7-fb7748bd3f04"
                                                                                                         siteName:@"srg-test-letterbox-apple"];
+    configuration.unitTesting = YES;
     [SRGAnalyticsTracker.sharedTracker startWithConfiguration:configuration];
 }

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -41,6 +41,6 @@ The SRG Letterbox library provides an advanced player with several features:
 * Thumbnail retrieval and display.
 * Error display.
 * Recovery after network loss.
-* Anonymous stream tracking conforming to internal (TagCommander / Webtrekk) and legal (Mediapulse) specifications.
+* Anonymous stream tracking conforming to internal (Commanders Act / Webtrekk) and legal (Mediapulse) specifications.
 
 


### PR DESCRIPTION
## Description

The PR follows `SRGAnalytics` update regarding Commanders Act update to version 5: https://github.com/SRGSSR/srganalytics-apple/issues/62

## Changes made

- Update `SRGAnalytics` dependency.
- Update `TrackerSingleton` for tests setup, like `SRGAnalytics` tests setup.
- Remove internal environnement API (preprod and prod) and related test.
- Switch analytics configuration to SRG and new site name.

Demo:
- Update configuration API to support source keys instead of container identifiers.
- Update page view tracking API to use mandatory page type support.
- Rename hidden event as event to follow updated API.