### PR TITLE
Valid time duration to NSDateComponentsFormatter

### DIFF
--- a/Demo/SRGLetterbox-demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/SRGLetterbox-demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -141,8 +141,8 @@
         "repositoryURL": "https://github.com/SRGSSR/srgmediaplayer-apple.git",
         "state": {
           "branch": null,
-          "revision": "63a8b41213360f625f2171a18718a7e5f14c4874",
-          "version": "7.2.0"
+          "revision": "717608146d3787bd269d5a524e109ee30be828e4",
+          "version": "7.2.1"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -123,8 +123,8 @@
         "repositoryURL": "https://github.com/SRGSSR/srgmediaplayer-apple.git",
         "state": {
           "branch": null,
-          "revision": "63a8b41213360f625f2171a18718a7e5f14c4874",
-          "version": "7.2.0"
+          "revision": "717608146d3787bd269d5a524e109ee30be828e4",
+          "version": "7.2.1"
         }
       },
       {

--- a/Sources/SRGLetterbox/SRGControlsView~ios.m
+++ b/Sources/SRGLetterbox/SRGControlsView~ios.m
@@ -669,6 +669,7 @@ static NSDateComponentsFormatter *SRGControlsViewSkipIntervalAccessibilityFormat
     CMTimeRange timeRange = self.controller.timeRange;
     if (SRG_CMTIMERANGE_IS_DEFINITE(timeRange) && SRG_CMTIMERANGE_IS_NOT_EMPTY(timeRange)) {
         NSTimeInterval durationInSeconds = CMTimeGetSeconds(timeRange.duration);
+        // TODO: Use `SRGMediaPlayer` macro named `SRG_NSTIMEINTERVAL_IS_VALID(interval)` when library is released.
         if (! (isnan(durationInSeconds) || isinf(durationInSeconds))) {
             if (durationInSeconds < 60. * 60.) {
                 self.durationLabel.text = [NSDateComponentsFormatter.srg_shortDateComponentsFormatter stringFromTimeInterval:durationInSeconds];

--- a/Sources/SRGLetterbox/SRGControlsView~ios.m
+++ b/Sources/SRGLetterbox/SRGControlsView~ios.m
@@ -669,14 +669,20 @@ static NSDateComponentsFormatter *SRGControlsViewSkipIntervalAccessibilityFormat
     CMTimeRange timeRange = self.controller.timeRange;
     if (SRG_CMTIMERANGE_IS_DEFINITE(timeRange) && SRG_CMTIMERANGE_IS_NOT_EMPTY(timeRange)) {
         NSTimeInterval durationInSeconds = CMTimeGetSeconds(timeRange.duration);
-        if (durationInSeconds < 60. * 60.) {
-            self.durationLabel.text = [NSDateComponentsFormatter.srg_shortDateComponentsFormatter stringFromTimeInterval:durationInSeconds];
+        if (! (isnan(durationInSeconds) || isinf(durationInSeconds))) {
+            if (durationInSeconds < 60. * 60.) {
+                self.durationLabel.text = [NSDateComponentsFormatter.srg_shortDateComponentsFormatter stringFromTimeInterval:durationInSeconds];
+            }
+            else {
+                self.durationLabel.text = [NSDateComponentsFormatter.srg_mediumDateComponentsFormatter stringFromTimeInterval:durationInSeconds];
+            }
+            
+            self.durationLabel.accessibilityLabel = [NSDateComponentsFormatter.srg_accessibilityDateComponentsFormatter stringFromTimeInterval:durationInSeconds];
         }
         else {
-            self.durationLabel.text = [NSDateComponentsFormatter.srg_mediumDateComponentsFormatter stringFromTimeInterval:durationInSeconds];
+            self.durationLabel.text = nil;
+            self.durationLabel.accessibilityLabel = nil;
         }
-        
-        self.durationLabel.accessibilityLabel = [NSDateComponentsFormatter.srg_accessibilityDateComponentsFormatter stringFromTimeInterval:durationInSeconds];
     }
     else {
         self.durationLabel.text = nil;

--- a/Sources/SRGLetterbox/SRGControlsView~ios.m
+++ b/Sources/SRGLetterbox/SRGControlsView~ios.m
@@ -669,8 +669,7 @@ static NSDateComponentsFormatter *SRGControlsViewSkipIntervalAccessibilityFormat
     CMTimeRange timeRange = self.controller.timeRange;
     if (SRG_CMTIMERANGE_IS_DEFINITE(timeRange) && SRG_CMTIMERANGE_IS_NOT_EMPTY(timeRange)) {
         NSTimeInterval durationInSeconds = CMTimeGetSeconds(timeRange.duration);
-        // TODO: Use `SRGMediaPlayer` macro named `SRG_NSTIMEINTERVAL_IS_VALID(interval)` when library is released.
-        if (! (isnan(durationInSeconds) || isinf(durationInSeconds))) {
+        if (SRG_NSTIMEINTERVAL_IS_VALID(durationInSeconds)) {
             if (durationInSeconds < 60. * 60.) {
                 self.durationLabel.text = [NSDateComponentsFormatter.srg_shortDateComponentsFormatter stringFromTimeInterval:durationInSeconds];
             }


### PR DESCRIPTION
### Motivation and Context

Documented in issue #302.

### Description

- Check `NSTimeInterval` is valid to the various used `NSDateComponentsFormatter`.
- [x] Update `SRGMediaPlayer` release with `SRG_NSTIMEINTERVAL_IS_VALID(interval)` is accepted. https://github.com/SRGSSR/srgmediaplayer-apple/pull/128

### Checklist

- [x] The branch should be rebased onto the `develop` branch for whole tests with last commits.
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.
