### PR TITLE
Fix unit test for not found media urn

### DIFF
--- a/Tests/SRGLetterboxTests/DiagnosticTestCase.m
+++ b/Tests/SRGLetterboxTests/DiagnosticTestCase.m
@@ -140,7 +140,7 @@ static NSString * const DiagnosticTestCasePlatform = @"iOS";
 
 - (void)testPlaybackReportForUnknownMedia
 {
-    NSString *URN = @"urn:swi:video:_UNKNOWN_ID_";
+    NSString *URN = @"urn:rts:video:1234";
     
     [self expectationForSingleNotification:SRGLetterboxPlaybackDidFailNotification object:self.controller handler:^BOOL(NSNotification * _Nonnull notification) {
         return YES;

--- a/Tests/SRGLetterboxTests/PlaybackTestCase.m
+++ b/Tests/SRGLetterboxTests/PlaybackTestCase.m
@@ -307,7 +307,7 @@
     XCTAssertEqual(self.controller.dataAvailability, SRGLetterboxDataAvailabilityNone);
     XCTAssertFalse(self.controller.loading);
     
-    [self.controller playURN:@"urn:swi:video:_NO_ID_" atPosition:nil withPreferredSettings:nil];
+    [self.controller playURN:@"urn:rts:video:1234" atPosition:nil withPreferredSettings:nil];
     
     XCTAssertEqual(self.controller.dataAvailability, SRGLetterboxDataAvailabilityLoading);
     XCTAssertTrue(self.controller.loading);


### PR DESCRIPTION
### Motivation and Context

Fix unit / integration tests.

### Description

Update unknown media urn which return `404`.

- `testPlayUnknownURN`.
- `testPlaybackReportForUnknownMedia`.

### Checklist

- [x] The branch should be rebased onto the `develop` branch for whole tests with nighties.
- [x] The documentation has been updated (if relevant).
- [x] The demo has been updated (if relevant).
- [x] Issues are linked to the PR, if any.