### PR TITLE
Add Pillarbox migration instructions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,11 @@
 
 [![GitHub releases](https://img.shields.io/github/v/release/SRGSSR/srgletterbox-apple)](https://github.com/SRGSSR/srgletterbox-apple/releases) [![platform](https://img.shields.io/badge/platfom-ios%20%7C%20tvos-blue)](https://github.com/SRGSSR/srgletterbox-apple) [![SPM compatible](https://img.shields.io/badge/SPM-compatible-4BC51D.svg?style=flat)](https://swift.org/package-manager) [![GitHub license](https://img.shields.io/github/license/SRGSSR/srgletterbox-apple)](https://github.com/SRGSSR/srgletterbox-apple/blob/master/LICENSE) 
 
+> [!IMPORTANT]
+> Letterbox will be sunset in August 2025 and will be replaced with [Pillarbox](https://github.com/SRGSSR/pillarbox-apple):
+>  - New SRG SSR products must use Pillarbox only.
+>  - Existing SRG SSR products using Letterbox must transition to Pillarbox before this date.
+
 ## About
 
 The SRG Letterbox library defines the official SRG SSR media player experience, packed into a single library providing:


### PR DESCRIPTION
# Description

Pillarbox will soon be delivered in version 1.0.0. This PR adds dedicated migration instructions to inform product teams they should use not use Letterbox anymore but rather upgrade to Pillarbox instead.

# Changes made

Self-explanatory.