### PR TITLE
Avoid audio leak on tvOS due to info view actions

### DIFF
--- a/Sources/SRGLetterbox/SRGLetterboxViewController~tvos.m
+++ b/Sources/SRGLetterbox/SRGLetterboxViewController~tvos.m
@@ -480,11 +480,13 @@ static NSMutableSet<SRGLetterboxViewController *> *s_letterboxViewControllers;
             
         case SRGStreamTypeDVR: {
             NSMutableArray<UIAction *> *infoViewActions = [NSMutableArray array];
+            @weakify(self)
             if ([self.controller canStartOver]) {
                 UIAction *action = [UIAction actionWithTitle:SRGLetterboxLocalizedString(@"Start over", @"Start over button label")
                                                        image:[UIImage srg_letterboxStartOverImageInSet:SRGImageSetNormal]
                                                   identifier:nil
                                                      handler:^(__kindof UIAction * _Nonnull action) {
+                    @strongify(self)
                     [self.controller startOverWithCompletionHandler:nil];
                 }];
                 [infoViewActions addObject:action];
@@ -494,6 +496,7 @@ static NSMutableSet<SRGLetterboxViewController *> *s_letterboxViewControllers;
                                                        image:[UIImage srg_letterboxSkipToLiveImageInSet:SRGImageSetNormal]
                                                   identifier:nil
                                                      handler:^(__kindof UIAction * _Nonnull action) {
+                    @strongify(self)
                     [self.controller skipToLiveWithCompletionHandler:nil];
                 }];
                 [infoViewActions addObject:action];


### PR DESCRIPTION
This PR fixes an audio leak on tvOS related to `infoViewActions`.

> [!WARNING] 
> This audio leak is still present on **Letterbox** in debug mode.

> [!NOTE] 
> This issue seems to have been encountered on **Pillarbox**(https://github.com/SRGSSR/pillarbox-apple/pull/1427).

## Change made

- A weak ref on self is used in the actions blocks.